### PR TITLE
Test case: Can have many live queries in one model

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,11 +692,14 @@ made promise-friendly using [Bluebird's promisification feature](http://bluebird
 
 var LinvoDB = require("linvodb3");
 var Promise = require("bluebird");
-Promise.promisifyAll(LinvoDB);
+
+var Planet = new LinvoDB('planet', {});
+
+Promise.promisifyAll(Planet.find().__proto__);
 // As of this line, LinvoDB APIs now have promise-returning methods with *Async suffix.
 // All the callback-based APIs are still there and will work as before.
 
-Planet.findAsync({ system: 'solar' }).then(function(docs) {
+Planet.find({ system: 'solar' }).limit(10).execAsync().then(function(docs) {
 	// use docs somehow
 }).catch(function(err) {
 	// handle errors
@@ -705,7 +708,7 @@ Planet.findAsync({ system: 'solar' }).then(function(docs) {
 // or, if you use ES7 async / await:
 
 try {
-	var docs = await Planet.findAsync({ system: 'solar' });
+	var docs = await Planet.find({ system: 'solar' }).limit(10).execAsync();
 	// use docs somehow
 } catch (err) {
 	// handle errors

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -1135,6 +1135,26 @@ describe('Cursor', function () {
       done();
     });
 
+    it('Can have many live queries in one model', function (done) {
+      done = _.once(done);
+
+      var liveFind, liveCount;
+
+      // comment one of these two to work
+      liveFind = d.find({}).live();
+      liveCount = d.find({}).count().live();
+
+      d.on("liveQueryUpdate", function() {
+        if (liveFind)
+          liveFind.res.length.should.equal(7);
+
+        if (liveCount)
+          liveCount.res.should.equal(7);
+
+        done();
+      });
+    });
+
   }); // End of 'Live Query'
 
 });


### PR DESCRIPTION
Now it is impossible to have more than one live query in particular model hence that limits usage of this functionality. I believe attaching liveQueryUpdate event handler to live query instance would be better  than attaching to model instance (and semantically more correct as well).  