### PR TITLE
Update insert() to return a one or multiple docs based upon incoming data

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -260,6 +260,7 @@ Model.prototype.updateIndexes = function (oldDoc, newDoc) {
  *
  */
 Model.prototype.insert = function (newDoc, cb) {
+  var multiDoc = util.isArray(newDoc);
   var callback = cb || function () {}
     , self = this
     ;
@@ -283,7 +284,7 @@ Model.prototype.insert = function (newDoc, cb) {
       d._persist(cb);
     }, function(err, docs) {
       self.emit("inserted", docs);
-      callback(err || null, err ? undefined : docs[0]);
+      callback(err || null, err ? undefined : (multiDoc ? docs : docs[0]));
     });
   });
 

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -611,7 +611,7 @@ describe('Database', function () {
         { tf: 5, r: 6 },        
         { tf: 10, r: 10 },
       ], function (err, docs) {
-        doc = docs;
+        doc = docs[0];
         getCandidates({ r: { $exists: true, $lt: 5 } }, null, function(data) {
             data.length.should.equal(1);
             assert.deepEqual(doc, data[0]);


### PR DESCRIPTION
On insert(), if the incoming 'newDoc' is an array of documents, then the callback should return the final array of documents. Otherwise, return just the first.

This is a fix for #20 and #33 