### PR TITLE
reference bagpipe with direct commit number to fix #83

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "async": "1.x.x",
-    "bagpipe": "Ivshti/bagpipe",
+    "bagpipe": "Ivshti/bagpipe#ae11730ef59364b20868287fb3ce0970a87dc8c8",
     "binary-search-tree": "0.2.6",
     "hat": "0.0.3",
     "levelup": "^1.2.1",


### PR DESCRIPTION
This is a temporary workaround for bagpipe to install successfully in latest npm versions, until proper github package resolution is available