### PR TITLE
Fix 16-characters in createNewId

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -302,7 +302,7 @@ Model.prototype.insert = function (newDoc, cb) {
  * Create a new _id that's not already in use
  */
 Model.prototype.createNewId = function () {
-  var tentativeId = hat(32);
+  var tentativeId = hat(64);
   if (this.indexes._id.getMatching(tentativeId).length > 0) {
     tentativeId = this.createNewId();
   }


### PR DESCRIPTION
It fixes the 16 characters length in id generator function `createNewId` and fixes the test case in https://github.com/Ivshti/linvodb3/pull/71